### PR TITLE
[enh] remove all app directories

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -56,6 +56,8 @@ ynh_print_info "Removing app main directory"
 
 # Remove the app directory securely
 ynh_secure_remove "$final_path"
+ynh_secure_remove "/etc/jellyfin"
+ynh_secure_remove "/var/lib/jellyfin"
 
 #=================================================
 # REMOVE NGINX CONFIGURATION


### PR DESCRIPTION
After removal, two directories are left,
and they prevent subsequent reinstallations of the app.